### PR TITLE
Prominently state that posters are also possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # :film_projector: fau-beamer
 
-A LaTeX beamer template according to the 2021 [style guide](https://www.intern.fau.de/kommunikation-und-marke/corporate-design/) of [Friedrich-Alexander-Universität Erlangen-Nürnberg](https://www.fau.de/).
+A LaTeX beamer and poster template according to the 2021 [style guide](https://www.intern.fau.de/kommunikation-und-marke/corporate-design/) of [Friedrich-Alexander-Universität Erlangen-Nürnberg](https://www.fau.de/).
 
-The given template allows you to create LaTeX presentations with the [beamer class](https://ctan.org/pkg/beamer?lang=en) in the corporate style of FAU.
+The given template allows you to create LaTeX presentations and posters with the [beamer class](https://ctan.org/pkg/beamer?lang=en) in the corporate style of FAU.
 
 ## :gear: Usage and Most Important Options
 


### PR DESCRIPTION
Hey, thank you for providing this awesome repository and fau-beamer template.

While searching for poster templates that match FAU's style guide, I came across this repository, but initially skipped it because it only mentioned presentations.

Maybe it is clear to others that fau-beamer also includes a poster template, but it was not to me. I acknowledge it might be an oversight on my part, but it would have helped if the README had mentioned posters.

This is only a minor modification. Feel free to commit this change yourself and close this pull request.
I just opened the pull request to address this update.